### PR TITLE
Add mouse move control to next screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ HammerSpoon config file - by S1ngS1ng
 * **NEW Feature** [Global VIM-like Key Binding](./vim-binding.lua) (Thanks to [@A-RON](https://github.com/asmagill))
     * `Ctrl` + `hjkl` for `Left, Down, Up and Right`
     * Works with combinations of `Alt`, `Cmd` and `Shift`
-* **NEW Feature** [Mouse Move to next screen]
+* **NEW Feature** [Mouse Move to next screen](./mouse-control.lua)
     * Move mouse to next screen and center it
 
 # Example

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ HammerSpoon config file - by S1ngS1ng
 * **NEW Feature** [Global VIM-like Key Binding](./vim-binding.lua) (Thanks to [@A-RON](https://github.com/asmagill))
     * `Ctrl` + `hjkl` for `Left, Down, Up and Right`
     * Works with combinations of `Alt`, `Cmd` and `Shift`
+* **NEW Feature** [Mouse Move to next screen]
+    * Move mouse to next screen and center it
 
 # Example
 ## VIM Key Binding
@@ -84,6 +86,9 @@ HammerSpoon config file - by S1ngS1ng
 * Windows-like window cycle (Just like winKey + left/right on Windows OS)
     * `Ctrl-Alt-Command + u` - Move window to the "relative" left and resize to half of the screen
     * `Ctrl-Alt-Command + i` - Move window to the "relative" right and resize to half of the screen
+
+## Mouse Move
+* `Ctrl-Command + M` - Move mouse to next screen and center it
 
 ## VOX
 * `Alt-Command-Shift + J` - Toggle Play and Pause

--- a/key-binding.lua
+++ b/key-binding.lua
@@ -1,4 +1,5 @@
 local wm = require('window-management')
+local ms = require('mouse-control')
 local hk = require "hs.hotkey"
 
 -- * Key Binding Utility
@@ -14,10 +15,17 @@ local function windowBind(hyper, keyFuncTable)
   end
 end
 
+local mouseBind = windowBind
+
 -- * Move window to screen
 windowBind({"ctrl", "alt"}, {
   left = wm.throwLeft,
   right = wm.throwRight
+})
+
+-- * Move mouse to next screen
+mouseBind({"ctrl", "cmd"}, {
+  m = ms.moveNext
 })
 
 -- * Set Window Position on screen

--- a/mouse-control.lua
+++ b/mouse-control.lua
@@ -1,12 +1,3 @@
-#! /usr/bin/env lua
---
--- mouse-control.lua
--- Copyright (C) 2018 YongMan <YongMan@YongMBP.local>
---
--- Distributed under terms of the MIT license.
---
-
--- Move mouse to left screen
 module = {}
 
 -- Move mouse to next screen

--- a/mouse-control.lua
+++ b/mouse-control.lua
@@ -1,0 +1,23 @@
+#! /usr/bin/env lua
+--
+-- mouse-control.lua
+-- Copyright (C) 2018 YongMan <YongMan@YongMBP.local>
+--
+-- Distributed under terms of the MIT license.
+--
+
+-- Move mouse to left screen
+module = {}
+
+-- Move mouse to next screen
+module.moveNext = function()
+  local screen = hs.mouse.getCurrentScreen()
+  local nextScreen = screen:next()
+  local rect = nextScreen:fullFrame()
+  local center = hs.geometry.rectMidPoint(rect)
+
+  hs.mouse.setAbsolutePosition(center)
+end
+
+return module
+


### PR DESCRIPTION
Mouse move between screens is terrible if using `touchpad` or `trackpad`, we can use `hammerspoon` to control mouse move to next screen quickly.